### PR TITLE
Todoist から始まる拡張名は使えないので、拡張のタイトルを変更

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Todoist Counter"
+    "message": "Counter for Todoist"
   },
   "extensionDescription": {
     "message": "Displays the number of uncompleted tasks in Todoist on the toolbar."

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Todoist Counter：未完了のタスクの数を表示"
+    "message": "Counter for Todoist：未完了のタスクの数を表示"
   },
   "extensionDescription": {
     "message": "Todoist の未完了のタスクの数をツールバーに表示"


### PR DESCRIPTION
[Marketing your app – Guides | Todoist Developer](https://developer.todoist.com/guides/#marketing-your-app)

Todoist から始まる拡張名は使えない